### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,10 @@
 name: Java CI - Build & Package
 
+permissions:
+  contents: read
+  packages: read
+  artifacts: write
+
 on:
   push:
     branches: [ "main", "develop" ]


### PR DESCRIPTION
Potential fix for [https://github.com/ggasnier/education-annuaire/security/code-scanning/1](https://github.com/ggasnier/education-annuaire/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the actions used in the workflow:
- `contents: read` is sufficient for checking out the code.
- `packages: read` may be required for caching Maven dependencies.
- `contents: write` is not needed since the workflow does not modify repository contents.
- `actions: read` may be required for interacting with GitHub Actions artifacts.
- `artifacts: write` is required for uploading the packaged JAR file.

The `permissions` block should be added at the root level of the workflow to apply to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
